### PR TITLE
Initial Vite+React TypeScript SPA: unified diff parsing, viewer, file tree, and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.vite
+.env
+.env.*
+dist

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Diff Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "web-diff-viewer",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "parse-diff": "^0.11.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-diff-view": "^3.3.1",
+    "refractor": "^4.8.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Diff, Hunk } from 'react-diff-view';
+import { refractor } from 'refractor/lib/common';
+import type { DiffFile } from './types';
+import { parseDiffText, type DiffViewHunk } from './utils/diff';
+
+const STORAGE_KEYS = {
+  rawText: 'diff-viewer:raw-text',
+  selectedFileId: 'diff-viewer:selected-file',
+  scrollPositions: 'diff-viewer:scroll-positions',
+  theme: 'diff-viewer:theme',
+} as const;
+
+const CHANGE_BADGES: Record<DiffFile['changeType'], string> = {
+  add: 'A',
+  modify: 'M',
+  delete: 'D',
+  rename: 'R',
+  binary: 'B',
+};
+
+const getDisplayPath = (file: DiffFile) => file.newPath || file.oldPath;
+
+const languageByExtension: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  json: 'json',
+  md: 'markdown',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  yml: 'yaml',
+  yaml: 'yaml',
+  py: 'python',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  rb: 'ruby',
+  php: 'php',
+  sh: 'bash',
+};
+
+const getLanguageFromPath = (path: string) => {
+  const match = path.split('.').pop();
+  if (!match) {
+    return 'text';
+  }
+  return languageByExtension[match] ?? 'text';
+};
+
+const tokenize = (code: string, language: string) => {
+  try {
+    return refractor.highlight(code, language);
+  } catch {
+    return refractor.highlight(code, 'text');
+  }
+};
+
+const readStoredScrollPositions = () => {
+  const stored = localStorage.getItem(STORAGE_KEYS.scrollPositions);
+  if (!stored) {
+    return {} as Record<string, number>;
+  }
+  try {
+    const parsed = JSON.parse(stored) as Record<string, number>;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    return {} as Record<string, number>;
+  }
+  return {} as Record<string, number>;
+};
+
+const storeScrollPositions = (positions: Record<string, number>) => {
+  localStorage.setItem(STORAGE_KEYS.scrollPositions, JSON.stringify(positions));
+};
+
+export default function App() {
+  const [rawText, setRawText] = useState('');
+  const [files, setFiles] = useState<DiffFile[]>([]);
+  const [viewHunksById, setViewHunksById] = useState<Record<string, DiffViewHunk[]>>({});
+  const [selectedFileId, setSelectedFileId] = useState('');
+  const [showTree, setShowTree] = useState(true);
+  const [error, setError] = useState('');
+  const [inputTab, setInputTab] = useState<'upload' | 'paste'>('upload');
+  const [pasteValue, setPasteValue] = useState('');
+  const [uploadValue, setUploadValue] = useState('');
+  const [scrollPositions, setScrollPositions] = useState<Record<string, number>>({});
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const storedRaw = localStorage.getItem(STORAGE_KEYS.rawText);
+    const storedFileId = localStorage.getItem(STORAGE_KEYS.selectedFileId);
+    const storedTheme = localStorage.getItem(STORAGE_KEYS.theme);
+
+    if (!storedTheme) {
+      localStorage.setItem(STORAGE_KEYS.theme, 'dark');
+    }
+
+    if (!storedRaw) {
+      return;
+    }
+
+    try {
+      const parsed = parseDiffText(storedRaw);
+      if (parsed.files.length === 0) {
+        return;
+      }
+      setRawText(storedRaw);
+      setFiles(parsed.files);
+      setViewHunksById(parsed.viewHunksById);
+      const initialFileId = storedFileId && parsed.files.some((file) => file.id === storedFileId)
+        ? storedFileId
+        : parsed.files[0].id;
+      setSelectedFileId(initialFileId);
+      setShowTree(false);
+      setScrollPositions(readStoredScrollPositions());
+    } catch (parseError) {
+      console.error(parseError);
+    }
+  }, []);
+
+  const selectedFile = files.find((file) => file.id === selectedFileId) ?? null;
+
+  const loadDiff = useCallback((text: string) => {
+    setError('');
+    if (!text.trim()) {
+      setError('Add a diff before loading.');
+      return;
+    }
+    try {
+      const parsed = parseDiffText(text);
+      if (parsed.files.length === 0) {
+        setError('No file patches found. Paste a GitLab unified diff.');
+        return;
+      }
+      setRawText(text);
+      setFiles(parsed.files);
+      setViewHunksById(parsed.viewHunksById);
+      setSelectedFileId(parsed.files[0].id);
+      setShowTree(true);
+      const positions = {} as Record<string, number>;
+      setScrollPositions(positions);
+      storeScrollPositions(positions);
+      localStorage.setItem(STORAGE_KEYS.rawText, text);
+      localStorage.setItem(STORAGE_KEYS.selectedFileId, parsed.files[0].id);
+    } catch (parseError) {
+      console.error(parseError);
+      setError('Unable to parse diff. Ensure it is a unified diff from GitLab.');
+    }
+  }, []);
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    file
+      .text()
+      .then((text) => {
+        setUploadValue(text);
+      })
+      .catch(() => {
+        setError('Could not read the file.');
+      });
+  };
+
+  const handlePasteLoad = () => {
+    loadDiff(pasteValue.trim());
+  };
+
+  const handleUploadLoad = () => {
+    loadDiff(uploadValue.trim());
+  };
+
+  const handleSelectFile = (file: DiffFile) => {
+    setSelectedFileId(file.id);
+    localStorage.setItem(STORAGE_KEYS.selectedFileId, file.id);
+    setShowTree(false);
+  };
+
+  const handleScroll = useCallback(() => {
+    const container = scrollRef.current;
+    if (!container || !selectedFileId) {
+      return;
+    }
+    setScrollPositions((prev) => {
+      const nextPositions = {
+        ...prev,
+        [selectedFileId]: container.scrollTop,
+      };
+      storeScrollPositions(nextPositions);
+      return nextPositions;
+    });
+  }, [selectedFileId]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || !selectedFileId) {
+      return;
+    }
+    const stored = scrollPositions[selectedFileId] ?? 0;
+    container.scrollTop = stored;
+  }, [selectedFileId, scrollPositions]);
+
+  const diffType = selectedFile?.changeType === 'binary' ? 'modify' : selectedFile?.changeType ?? 'modify';
+
+  const diffHunks = useMemo(() => {
+    if (!selectedFile) {
+      return [] as DiffViewHunk[];
+    }
+    return viewHunksById[selectedFile.id] ?? [];
+  }, [selectedFile, viewHunksById]);
+
+  if (!rawText) {
+    return (
+      <div className="app app--startup">
+        <div className="startup">
+          <header className="startup__header">
+            <h1>Web Diff Viewer</h1>
+            <p>Load a GitLab unified diff to review changes.</p>
+          </header>
+          <div className="tabs">
+            <button
+              type="button"
+              className={inputTab === 'upload' ? 'tab tab--active' : 'tab'}
+              onClick={() => setInputTab('upload')}
+            >
+              Upload
+            </button>
+            <button
+              type="button"
+              className={inputTab === 'paste' ? 'tab tab--active' : 'tab'}
+              onClick={() => setInputTab('paste')}
+            >
+              Paste
+            </button>
+          </div>
+          <div className="tab-panel">
+            {inputTab === 'upload' ? (
+              <div className="upload-panel">
+                <input type="file" accept=".diff,.patch" onChange={handleFileUpload} />
+                <button
+                  type="button"
+                  className="primary"
+                  onClick={handleUploadLoad}
+                  disabled={!uploadValue.trim()}
+                >
+                  Load diff
+                </button>
+              </div>
+            ) : (
+              <div className="paste-panel">
+                <textarea
+                  placeholder="Paste unified diff text..."
+                  value={pasteValue}
+                  onChange={(event) => setPasteValue(event.target.value)}
+                />
+                <button type="button" className="primary" onClick={handlePasteLoad}>
+                  Load diff
+                </button>
+              </div>
+            )}
+          </div>
+          {error ? <div className="error">{error}</div> : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="app">
+      <div className="viewer">
+        {showTree && (
+          <aside className="file-tree">
+            <div className="file-tree__header">
+              <h2>Files</h2>
+              <button type="button" className="ghost" onClick={() => setShowTree(false)}>
+                Hide
+              </button>
+            </div>
+            <ul className="file-tree__list">
+              {files.map((file) => (
+                <li key={file.id}>
+                  <button
+                    type="button"
+                    className={file.id === selectedFileId ? 'file-item file-item--active' : 'file-item'}
+                    onClick={() => handleSelectFile(file)}
+                  >
+                    <span className={`badge badge--${file.changeType}`}>{CHANGE_BADGES[file.changeType]}</span>
+                    <span className="file-path">{getDisplayPath(file) || 'Untitled file'}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+        <div className="code-viewer" ref={scrollRef} onScroll={handleScroll}>
+          {selectedFile ? (
+            selectedFile.isBinary ? (
+              <div className="binary-placeholder">
+                <h3>{getDisplayPath(selectedFile)}</h3>
+                <p>Binary file changed.</p>
+              </div>
+            ) : (
+              <Diff
+                viewType="unified"
+                diffType={diffType as 'add' | 'delete' | 'modify' | 'rename'}
+                hunks={diffHunks}
+                className="diff"
+                tokenize={(line: string) => tokenize(line, getLanguageFromPath(getDisplayPath(selectedFile)))}
+              >
+                {(hunks) => hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)}
+              </Diff>
+            )
+          ) : (
+            <div className="empty-state">Select a file to view its diff.</div>
+          )}
+        </div>
+        {!showTree && (
+          <button type="button" className="floating-button" onClick={() => setShowTree(true)}>
+            Files
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,38 @@
+declare module 'parse-diff' {
+  export interface Change {
+    type: 'normal' | 'add' | 'del';
+    content: string;
+    ln?: number;
+    ln1?: number;
+    ln2?: number;
+  }
+
+  export interface Chunk {
+    content: string;
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    changes: Change[];
+  }
+
+  export interface File {
+    chunks: Chunk[];
+    from: string;
+    to: string;
+    deletions: number;
+    additions: number;
+    oldMode?: string;
+    newMode?: string;
+    newFileMode?: string;
+    deletedFileMode?: string;
+    renameFrom?: string;
+    renameTo?: string;
+    newFile?: boolean;
+    deletedFile?: boolean;
+    renamed?: boolean;
+    binary?: boolean;
+  }
+
+  export default function parseDiff(input: string): File[];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+import 'react-diff-view/style/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,293 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'SF Pro Text', system-ui, sans-serif;
+  background-color: #0f1115;
+  color: #e6e6e6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0f1115;
+  overflow: hidden;
+}
+
+#root,
+.app {
+  height: 100dvh;
+  width: 100dvw;
+}
+
+.app {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.app--startup {
+  padding: 24px;
+}
+
+.startup {
+  width: min(640px, 100%);
+  margin: 0 auto;
+  padding: 32px 24px;
+  background: #171a21;
+  border-radius: 20px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+}
+
+.startup__header h1 {
+  margin: 0 0 8px;
+  font-size: 28px;
+}
+
+.startup__header p {
+  margin: 0 0 24px;
+  color: #a2a9b5;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tab {
+  flex: 1;
+  padding: 12px 16px;
+  background: #202530;
+  border: 1px solid #2e3340;
+  color: #c9cfda;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.tab--active {
+  background: #394256;
+  border-color: #4d5a77;
+  color: #fff;
+}
+
+.tab-panel {
+  margin-bottom: 16px;
+}
+
+.upload-panel,
+.paste-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+textarea {
+  min-height: 220px;
+  resize: vertical;
+  background: #0f1115;
+  border: 1px solid #2d3340;
+  border-radius: 12px;
+  padding: 12px;
+  color: #dfe3eb;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+}
+
+input[type='file'] {
+  background: #0f1115;
+  border: 1px dashed #2d3340;
+  border-radius: 12px;
+  padding: 16px;
+  color: #dfe3eb;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.primary {
+  background: #5d7cfa;
+  color: #0f1115;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 700;
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  margin-top: 8px;
+  padding: 12px 16px;
+  background: #36191d;
+  border: 1px solid #7a2d36;
+  border-radius: 12px;
+  color: #f4b5bf;
+}
+
+.viewer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #0f1115;
+}
+
+.file-tree {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: min(320px, 85vw);
+  background: #141821;
+  padding: 16px;
+  border-right: 1px solid #222736;
+  z-index: 10;
+  overflow-y: auto;
+  box-shadow: 8px 0 24px rgba(0, 0, 0, 0.4);
+}
+
+.file-tree__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.file-tree__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.file-tree__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: #1a1f2b;
+  color: #dfe3eb;
+  text-align: left;
+}
+
+.file-item--active {
+  border-color: #5d7cfa;
+  background: rgba(93, 124, 250, 0.12);
+}
+
+.badge {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.badge--add {
+  background: #193220;
+  color: #5be38a;
+}
+
+.badge--modify {
+  background: #232a3a;
+  color: #8aa2ff;
+}
+
+.badge--delete {
+  background: #3a1d1f;
+  color: #ff9ca6;
+}
+
+.badge--rename {
+  background: #2f2740;
+  color: #d0b2ff;
+}
+
+.badge--binary {
+  background: #2e2e2e;
+  color: #c9cfda;
+}
+
+.file-path {
+  font-size: 14px;
+  word-break: break-all;
+}
+
+.ghost {
+  background: transparent;
+  color: #c9cfda;
+  border: 1px solid #2d3340;
+  border-radius: 10px;
+  padding: 8px 12px;
+}
+
+.code-viewer {
+  height: 100%;
+  overflow: auto;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.diff {
+  padding: 24px 16px 120px;
+}
+
+.binary-placeholder,
+.empty-state {
+  padding: 48px 24px;
+  color: #c9cfda;
+}
+
+.binary-placeholder h3 {
+  margin-top: 0;
+}
+
+.floating-button {
+  position: fixed;
+  right: 16px;
+  bottom: 24px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: none;
+  background: #5d7cfa;
+  color: #0f1115;
+  font-weight: 700;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+  z-index: 20;
+}
+
+@media (min-width: 768px) {
+  .file-tree {
+    width: 360px;
+  }
+  .floating-button {
+    bottom: 32px;
+  }
+}
+
+.diff .diff-gutter {
+  background: #12161f;
+}
+
+.diff .diff-code {
+  background: #0f1115;
+}
+
+.diff .diff-line {
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,35 @@
+export type Theme = 'dark';
+
+export type ChangeType = 'add' | 'modify' | 'delete' | 'rename' | 'binary';
+
+export interface DiffLine {
+  type: 'add' | 'del' | 'normal';
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+  content: string;
+}
+
+export interface DiffHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: DiffLine[];
+}
+
+export interface DiffFile {
+  id: string;
+  oldPath: string;
+  newPath: string;
+  changeType: ChangeType;
+  hunks: DiffHunk[];
+  isBinary: boolean;
+}
+
+export interface DiffState {
+  rawText: string;
+  files: DiffFile[];
+  selectedFileId: string;
+  scrollByFileId: Record<string, number>;
+  theme: Theme;
+}

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,0 +1,115 @@
+import parseDiff, { Change, Chunk, File } from 'parse-diff';
+import { DiffFile, DiffHunk, DiffLine } from '../types';
+
+export interface DiffViewChange {
+  type: 'insert' | 'delete' | 'normal';
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+export interface DiffViewHunk {
+  content: string;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  changes: DiffViewChange[];
+}
+
+export interface ParsedDiffResult {
+  files: DiffFile[];
+  viewHunksById: Record<string, DiffViewHunk[]>;
+}
+
+const toLine = (change: Change): DiffLine => {
+  const oldLineNumber = change.type === 'add' ? null : change.ln1 ?? change.ln ?? null;
+  const newLineNumber = change.type === 'del' ? null : change.ln2 ?? change.ln ?? null;
+
+  return {
+    type: change.type === 'add' ? 'add' : change.type === 'del' ? 'del' : 'normal',
+    oldLineNumber,
+    newLineNumber,
+    content: change.content,
+  };
+};
+
+const toViewChange = (change: Change): DiffViewChange => {
+  const oldLineNumber = change.type === 'add' ? undefined : change.ln1 ?? change.ln;
+  const newLineNumber = change.type === 'del' ? undefined : change.ln2 ?? change.ln;
+
+  return {
+    type: change.type === 'add' ? 'insert' : change.type === 'del' ? 'delete' : 'normal',
+    content: change.content,
+    oldLineNumber,
+    newLineNumber,
+  };
+};
+
+const toHunk = (chunk: Chunk): DiffHunk => ({
+  oldStart: chunk.oldStart,
+  oldLines: chunk.oldLines,
+  newStart: chunk.newStart,
+  newLines: chunk.newLines,
+  lines: chunk.changes.map(toLine),
+});
+
+const toViewHunk = (chunk: Chunk): DiffViewHunk => ({
+  content: chunk.content,
+  oldStart: chunk.oldStart,
+  oldLines: chunk.oldLines,
+  newStart: chunk.newStart,
+  newLines: chunk.newLines,
+  changes: chunk.changes.map(toViewChange),
+});
+
+const getChangeType = (file: File): DiffFile['changeType'] => {
+  if (file.binary) {
+    return 'binary';
+  }
+  if (file.newFile || file.from === '/dev/null') {
+    return 'add';
+  }
+  if (file.deletedFile || file.to === '/dev/null') {
+    return 'delete';
+  }
+  if (file.renamed || file.renameFrom || file.renameTo) {
+    return 'rename';
+  }
+  return 'modify';
+};
+
+const normalizePath = (path: string) => path.replace(/^a\//, '').replace(/^b\//, '');
+
+const buildFileId = (file: File, index: number) => {
+  const from = file.renameFrom ?? file.from ?? '';
+  const to = file.renameTo ?? file.to ?? '';
+  return `${index}-${from}-${to}`;
+};
+
+export const parseDiffText = (rawText: string): ParsedDiffResult => {
+  const parsed = parseDiff(rawText);
+
+  const viewHunksById: Record<string, DiffViewHunk[]> = {};
+  const files = parsed.map((file, index) => {
+    const id = buildFileId(file, index);
+    const changeType = getChangeType(file);
+    const oldPath = normalizePath(file.renameFrom ?? file.from ?? '');
+    const newPath = normalizePath(file.renameTo ?? file.to ?? '');
+    const hunks = file.chunks.map(toHunk);
+    const viewHunks = file.chunks.map(toViewHunk);
+
+    viewHunksById[id] = viewHunks;
+
+    return {
+      id,
+      oldPath,
+      newPath,
+      changeType,
+      hunks,
+      isBinary: changeType === 'binary',
+    } satisfies DiffFile;
+  });
+
+  return { files, viewHunksById };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+});


### PR DESCRIPTION
### Motivation
- Provide a client-only, mobile-first single-page app that loads a single GitLab unified diff and lets users browse files and view unified diffs offline per SPEC/ADR.
- Persist last loaded diff, selected file, and per-file scroll position to localStorage for fast restore and continuity.

### Description
- Scaffolded a Vite + React + TypeScript app with `index.html`, `vite.config.ts`, `package.json`, TypeScript configs, and a small global stylesheet to implement the mobile-first dark theme and floating controls.
- Implemented `src/utils/diff.ts` that adapts `parse-diff` output into the app data model while preserving file order and detecting change types (add/modify/delete/rename/binary) and hunks for rendering.
- Built the main UI in `src/App.tsx` including Startup (Upload/Paste) flows, upload/paste handling, validation, file tree drawer, unified `react-diff-view` viewer with syntax tokenization via `refractor`, and localStorage persistence for raw diff, selected file, and scroll positions.
- Added types (`src/types.ts`) and module declarations (`src/declarations.d.ts`) and small UX improvements such as enabling the upload "Load diff" button only after reading the file and using a safer state update for scroll position storage.

### Testing
- Dependency installation failed in the environment (`npm install` returned 403 Forbidden from registry), so automated tests and dev server were not run.
- No unit or integration tests were executed in this run due to the unavailable dependencies; test scripts are present (`vitest`) and can be run once dependencies are installable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968d4bf7154832c889399495141c171)